### PR TITLE
fix(downloads): sanitize LLM-controlled filenames and folder paths (CWE-22)

### DIFF
--- a/packages/browser-runtime/src/tools/tools/downloads/index.ts
+++ b/packages/browser-runtime/src/tools/tools/downloads/index.ts
@@ -1,5 +1,6 @@
 import { tool } from "@aipexstudio/aipex-core";
 import { z } from "zod";
+import { sanitizeDownloadPath, sanitizeSegment } from "./sanitize-path";
 
 interface DownloadInfo {
   id: number;
@@ -137,7 +138,10 @@ export async function downloadTextAsMarkdown(
       .toISOString()
       .replace(/[:.]/g, "-")
       .slice(0, -5);
-    const baseFilename = filename || `text-${timestamp}`;
+    const baseFilename = sanitizeSegment(
+      filename || `text-${timestamp}`,
+      `text-${timestamp}`,
+    );
 
     const mdFilename = baseFilename.endsWith(".md")
       ? baseFilename
@@ -282,10 +286,13 @@ export const downloadImageTool = tool({
         .toISOString()
         .replace(/[:.]/g, "-")
         .slice(0, -5);
-      const baseFilename = filename || `image-${timestamp}`;
+      const baseFilename = sanitizeSegment(
+        filename || `image-${timestamp}`,
+        `image-${timestamp}`,
+      );
       const fullFilename = `${baseFilename}.${imageFormat}`;
       const finalPath = folderPath
-        ? `${folderPath}/${fullFilename}`
+        ? sanitizeDownloadPath(`${folderPath}/${fullFilename}`)
         : fullFilename;
 
       const downloadId = await chrome.downloads.download({
@@ -361,6 +368,10 @@ export const downloadChatImagesTool = tool({
         };
       }
 
+      const sanitizedFolderPrefix = folderPrefix
+        ? sanitizeDownloadPath(folderPrefix)
+        : undefined;
+
       const downloadIds: number[] = [];
       const errors: string[] = [];
       const filesList: string[] = [];
@@ -380,10 +391,13 @@ export const downloadChatImagesTool = tool({
                 .replace(/[:.]/g, "-")
                 .slice(0, -5);
               const titleSlug = part.imageTitle
-                ? part.imageTitle
-                    .toLowerCase()
-                    .replace(/[^a-z0-9]+/g, "-")
-                    .replace(/^-+|-+$/g, "")
+                ? sanitizeSegment(
+                    part.imageTitle
+                      .toLowerCase()
+                      .replace(/[^a-z0-9]+/g, "-")
+                      .replace(/^-+|-+$/g, ""),
+                    `image-${imageIndex}`,
+                  )
                 : `image-${imageIndex}`;
 
               let baseFilename: string;
@@ -401,9 +415,9 @@ export const downloadChatImagesTool = tool({
 
               const mimeMatch = part.imageData.match(/data:image\/([^;]+)/);
               const imageFormat = mimeMatch ? mimeMatch[1] : "png";
-              const fullFilename = `${baseFilename}.${imageFormat}`;
-              const finalPath = folderPrefix
-                ? `${folderPrefix}/${fullFilename}`
+              const fullFilename = `${sanitizeSegment(baseFilename)}.${imageFormat}`;
+              const finalPath = sanitizedFolderPrefix
+                ? `${sanitizedFolderPrefix}/${fullFilename}`
                 : fullFilename;
 
               const downloadId = await chrome.downloads.download({
@@ -429,7 +443,7 @@ export const downloadChatImagesTool = tool({
         downloadedCount,
         downloadIds,
         errors: errors.length > 0 ? errors : undefined,
-        folderPath: folderPrefix ?? undefined,
+        folderPath: sanitizedFolderPrefix ?? undefined,
         filesList,
       };
     } catch (error: unknown) {

--- a/packages/browser-runtime/src/tools/tools/downloads/sanitize-path.test.ts
+++ b/packages/browser-runtime/src/tools/tools/downloads/sanitize-path.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeDownloadPath, sanitizeSegment } from "./sanitize-path";
+
+describe("sanitizeSegment", () => {
+  it("returns simple names unchanged", () => {
+    expect(sanitizeSegment("hello")).toBe("hello");
+    expect(sanitizeSegment("my-file")).toBe("my-file");
+  });
+
+  it("strips path separators", () => {
+    expect(sanitizeSegment("a/b")).toBe("ab");
+    expect(sanitizeSegment("a\\b")).toBe("ab");
+    expect(sanitizeSegment("/etc/passwd")).toBe("etcpasswd");
+  });
+
+  it("removes .. traversal sequences", () => {
+    expect(sanitizeSegment("..")).toBe("download");
+    expect(sanitizeSegment("....")).toBe("download");
+    expect(sanitizeSegment("..foo")).toBe("foo");
+  });
+
+  it("removes control characters", () => {
+    expect(sanitizeSegment("file\x00name")).toBe("filename");
+    expect(sanitizeSegment("file\x1fname")).toBe("filename");
+  });
+
+  it("removes illegal filesystem characters", () => {
+    expect(sanitizeSegment('file<>:"|?*name')).toBe("filename");
+  });
+
+  it("trims leading/trailing dots and spaces", () => {
+    expect(sanitizeSegment(".hidden")).toBe("hidden");
+    expect(sanitizeSegment("file.")).toBe("file");
+    expect(sanitizeSegment("  file  ")).toBe("file");
+  });
+
+  it("returns fallback for empty result", () => {
+    expect(sanitizeSegment("")).toBe("download");
+    expect(sanitizeSegment("///")).toBe("download");
+    expect(sanitizeSegment("...", "fallback")).toBe("fallback");
+  });
+});
+
+describe("sanitizeDownloadPath", () => {
+  it("preserves simple folder/file paths", () => {
+    expect(sanitizeDownloadPath("folder/file")).toBe("folder/file");
+    expect(sanitizeDownloadPath("a/b/c")).toBe("a/b/c");
+  });
+
+  it("blocks classic path traversal — no .. in result", () => {
+    const result = sanitizeDownloadPath("../../../etc/passwd");
+    expect(result).not.toContain("..");
+    // ".." segments are dropped; "etc" and "passwd" survive
+    expect(result).toBe("etc/passwd");
+  });
+
+  it("blocks traversal via backslash", () => {
+    const result = sanitizeDownloadPath("..\\..\\Desktop\\malware");
+    expect(result).not.toContain("..");
+    expect(result).toBe("Desktop/malware");
+  });
+
+  it("blocks mixed traversal", () => {
+    const result = sanitizeDownloadPath("folder/../../secret");
+    expect(result).not.toContain("..");
+    expect(result).toBe("folder/secret");
+  });
+
+  it("collapses empty segments", () => {
+    expect(sanitizeDownloadPath("a//b")).toBe("a/b");
+    expect(sanitizeDownloadPath("/a/b/")).toBe("a/b");
+  });
+
+  it("returns fallback for entirely malicious input", () => {
+    expect(sanitizeDownloadPath("../../..")).toBe("download");
+    expect(sanitizeDownloadPath("")).toBe("download");
+  });
+
+  it("handles realistic attack payloads", () => {
+    // Payload: attempt to write to Desktop via traversal
+    const payload = "../../../Desktop/malware";
+    const result = sanitizeDownloadPath(payload);
+    expect(result).not.toContain("..");
+    expect(result).toBe("Desktop/malware");
+  });
+
+  it("strips illegal chars from individual segments", () => {
+    expect(sanitizeDownloadPath("my<folder>/my:file")).toBe("myfolder/myfile");
+  });
+});

--- a/packages/browser-runtime/src/tools/tools/downloads/sanitize-path.ts
+++ b/packages/browser-runtime/src/tools/tools/downloads/sanitize-path.ts
@@ -1,0 +1,57 @@
+/**
+ * Sanitize a single filename or folder segment for use with chrome.downloads.download().
+ *
+ * Rules:
+ * - Strip any path separators (/ and \)
+ * - Reject ".." to prevent directory traversal
+ * - Remove control characters and characters illegal on common filesystems
+ * - Collapse leading/trailing dots and spaces (Windows restriction)
+ * - Return a safe fallback when the result would be empty
+ */
+export function sanitizeSegment(
+  segment: string,
+  fallback = "download",
+): string {
+  let s = segment;
+
+  // Remove path separators
+  s = s.replace(/[/\\]/g, "");
+
+  // Remove directory traversal patterns that survive separator stripping
+  // (e.g. "..foo" after separator removal)
+  s = s.replace(/\.\./g, "");
+
+  // Remove control characters (U+0000–U+001F, U+007F) via character code filtering
+  s = Array.from(s)
+    .filter((ch) => {
+      const code = ch.charCodeAt(0);
+      return code > 0x1f && code !== 0x7f;
+    })
+    .join("");
+
+  // Remove characters illegal on Windows/macOS/Linux filesystems
+  s = s.replace(/[<>:"|?*]/g, "");
+
+  // Collapse leading/trailing dots and spaces
+  s = s.replace(/^[.\s]+/, "").replace(/[.\s]+$/, "");
+
+  return s.length > 0 ? s : fallback;
+}
+
+/**
+ * Sanitize a download path that may contain folder segments.
+ *
+ * Each segment between separators is individually sanitized.  Empty segments
+ * and lone ".." segments are dropped entirely, preventing traversal.
+ */
+export function sanitizeDownloadPath(
+  rawPath: string,
+  fallback = "download",
+): string {
+  const segments = rawPath
+    .split(/[/\\]/)
+    .map((seg) => sanitizeSegment(seg, ""))
+    .filter((seg) => seg.length > 0);
+
+  return segments.length > 0 ? segments.join("/") : fallback;
+}


### PR DESCRIPTION
## Summary

The download tools in `packages/browser-runtime/src/tools/tools/downloads/index.ts` pass LLM-supplied `filename`, `folderPath`, and `folderPrefix` arguments directly to `chrome.downloads.download()` without sanitization. This PR adds a small sanitization layer plus unit tests.

- **CWE-22**: Improper limitation of a pathname to a restricted directory
- **Affected file**: `packages/browser-runtime/src/tools/tools/downloads/index.ts`
- **Affected tools**: `downloadTextAsMarkdown`, `downloadImageTool`, `downloadChatImagesTool`

## Data flow

1. The AI agent reads attacker-influenced content (web page text, chat content, tool output).
2. Via prompt injection, the model is convinced to invoke a download tool with a crafted `filename` / `folderPath` / `folderPrefix` (e.g. `../../Desktop/evil`, names with control chars or Windows-illegal characters, leading dots, etc.).
3. The raw string flows into `chrome.downloads.download({ filename: ... })`.
4. For `downloadImageTool` and `downloadChatImagesTool` the call uses `saveAs: false`, so no Save-As dialog is shown — the user does not get a chance to notice the unusual path.

## Fix

New helpers in `downloads/sanitize-path.ts`:

- `sanitizeSegment(name, fallback)` — strips `/` and `\`, removes `..` sequences, drops control chars (U+0000–U+001F, U+007F), strips Windows-illegal chars `< > : " | ? *`, trims leading/trailing dots and spaces, and falls back to a safe default if the result is empty.
- `sanitizeDownloadPath(path, fallback)` — splits on `/` or `\`, sanitizes each segment, drops empty/`..`-only segments, and rejoins with `/`.

Applied at every sink in `downloads/index.ts`:

- `downloadTextAsMarkdown` — sanitize `filename`.
- `downloadImageTool` — sanitize `filename` and `folderPath`.
- `downloadChatImagesTool` — sanitize `folderPrefix` once and reuse, sanitize each per-image `baseFilename`, and return the sanitized folder in the result so the response reflects what was actually written.

The change is intentionally scoped: it does not alter tool schemas, behaviour for benign inputs, or any unrelated code paths.

## Tests

Added `downloads/sanitize-path.test.ts` with 15 cases covering:

- Identity for safe names (`hello`, `my-file`, `folder/file`).
- Path-separator stripping (`a/b`, `a\b`, `/etc/passwd`).
- `..` traversal (`..`, `....`, `../../../etc/passwd`, `..\..\Desktop\malware`, `folder/../../secret`).
- Control characters (`\x00`, `\x1f`).
- Windows-illegal chars (`< > : " | ? *`).
- Leading/trailing dots and spaces.
- Empty / fully-malicious input → fallback.
- Realistic payload (`../../../Desktop/malware` → `Desktop/malware`).

All tests pass under `vitest`, and the repo's `npm run preflight` (lint/typecheck/format) passes on the branch.

## Security analysis

The realistic threat model is prompt injection from page or chat content the agent is asked to process. The `saveAs: false` calls in the image tools are the most user-invisible sink, since no dialog warns the user about the destination.

Chrome's `downloads` API already rejects literal `..` back-references and absolute paths at the platform level, so this isn't an arbitrary-write-anywhere primitive — files still land under the user's Downloads root. The remaining risk that this PR addresses is:

- crafted filenames with control chars / illegal characters causing Chrome download errors (UX) or misleading filenames (e.g. RTL override, `\x00` truncation tricks),
- subtle traversal attempts that Chrome may or may not normalize the same way across platforms,
- attacker-chosen subpaths inside Downloads (this PR doesn't restrict to an allowlist — that was out of scope and matches existing behaviour),
- the response object accurately reporting the path that was actually written.

So this is best characterised as defense-in-depth and hardening of an LLM-reachable sink, not a sandbox escape patch.

### Adversarial review

Before submitting, we tried to disprove this. The main candidate mitigation is Chrome itself: `chrome.downloads.download` does sanitize obvious traversal. That eliminates the worst case (writing outside Downloads), which is why we're framing this as hardening rather than a critical bug. However, the tool args still flow into a security-relevant API from an LLM-controlled source with no validation, the image tools bypass the Save-As dialog, and there is no upstream framework protection between the tool argument and the Chrome API call — so the small sanitizer is genuinely useful and worth landing.

## Files changed

- `packages/browser-runtime/src/tools/tools/downloads/sanitize-path.ts` (new, 57 lines)
- `packages/browser-runtime/src/tools/tools/downloads/sanitize-path.test.ts` (new, 90 lines)
- `packages/browser-runtime/src/tools/tools/downloads/index.ts` (sanitize calls at three sinks)

Happy to adjust scope, naming, or fallback behaviour if you'd prefer a different convention.

cc @lewiswigmore
