### PR TITLE
fix(browser-runtime): prevent path traversal in SKILL_API filesystem bridge (CWE-22)

### DIFF
--- a/packages/browser-runtime/src/lib/vm/skill-api.test.ts
+++ b/packages/browser-runtime/src/lib/vm/skill-api.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for path traversal protection in the SKILL_API filesystem bridge.
+ *
+ * CWE-22: Skill code running in QuickJS VM can pass arbitrary paths to
+ * filesystem operations. Without validation, one skill can read/write/delete
+ * files belonging to other skills within the virtual filesystem.
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createSkillAPIBridge } from "./skill-api";
+
+// Mock zenfs-manager so we don't need a real IndexedDB / ZenFS backend
+vi.mock("./zenfs-manager", () => {
+  const noop = vi.fn().mockResolvedValue(undefined);
+  const noopSync = vi.fn();
+  return {
+    zenfs: {
+      readFile: vi.fn().mockResolvedValue("file-content"),
+      writeFile: noop,
+      readdir: vi.fn().mockResolvedValue([]),
+      exists: vi.fn().mockResolvedValue(true),
+      mkdir: noop,
+      rm: noop,
+      stat: vi.fn().mockResolvedValue({
+        isFile: true,
+        isDirectory: false,
+        size: 10,
+        mtime: new Date(),
+      }),
+      existsSync: vi.fn().mockReturnValue(true),
+      readFileSync: vi.fn().mockReturnValue("file-content"),
+      writeFileSync: noopSync,
+      readdirSync: vi.fn().mockReturnValue([]),
+      mkdirSync: noopSync,
+      rmSync: noopSync,
+      statSync: vi.fn().mockReturnValue({
+        isFile: true,
+        isDirectory: false,
+        size: 10,
+        mtime: new Date(),
+      }),
+    },
+  };
+});
+
+describe("skill-api path traversal protection", () => {
+  const SKILL_ID = "test-skill-abc";
+  let api: ReturnType<typeof createSkillAPIBridge>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api = createSkillAPIBridge({ skillId: SKILL_ID });
+  });
+
+  // ── Async methods ──────────────────────────────────────────────────
+
+  describe("async fs methods reject path traversal", () => {
+    it("readFile rejects '..' traversal", async () => {
+      await expect(
+        api.fs.readFile("../../other-skill/secrets.json"),
+      ).rejects.toThrow();
+    });
+
+    it("readFile rejects absolute path to another skill", async () => {
+      await expect(
+        api.fs.readFile("/skills/other-skill/data.json"),
+      ).rejects.toThrow();
+    });
+
+    it("writeFile rejects '..' traversal", async () => {
+      await expect(
+        api.fs.writeFile("../other-skill/payload", "pwned"),
+      ).rejects.toThrow();
+    });
+
+    it("readdir rejects traversal to parent", async () => {
+      await expect(api.fs.readdir("../../")).rejects.toThrow();
+    });
+
+    it("exists rejects traversal", async () => {
+      await expect(api.fs.exists("../other-skill")).rejects.toThrow();
+    });
+
+    it("mkdir rejects traversal", async () => {
+      await expect(api.fs.mkdir("../../etc")).rejects.toThrow();
+    });
+
+    it("rm rejects traversal", async () => {
+      await expect(
+        api.fs.rm("../other-skill", { recursive: true }),
+      ).rejects.toThrow();
+    });
+
+    it("stat rejects traversal", async () => {
+      await expect(api.fs.stat("../../other-skill")).rejects.toThrow();
+    });
+  });
+
+  // ── Sync methods ───────────────────────────────────────────────────
+
+  describe("sync fs methods reject path traversal", () => {
+    it("existsSync rejects traversal", () => {
+      expect(() => api.fs.existsSync("../../other-skill")).toThrow();
+    });
+
+    it("readFileSync rejects traversal", () => {
+      expect(() => api.fs.readFileSync("../other-skill/data")).toThrow();
+    });
+
+    it("writeFileSync rejects traversal", () => {
+      expect(() =>
+        api.fs.writeFileSync("../other-skill/payload", "pwned"),
+      ).toThrow();
+    });
+
+    it("readdirSync rejects traversal", () => {
+      expect(() => api.fs.readdirSync("../../")).toThrow();
+    });
+
+    it("mkdirSync rejects traversal", () => {
+      expect(() => api.fs.mkdirSync("../../etc")).toThrow();
+    });
+
+    it("rmSync rejects traversal", () => {
+      expect(() => api.fs.rmSync("../other-skill")).toThrow();
+    });
+
+    it("statSync rejects traversal", () => {
+      expect(() => api.fs.statSync("../../other-skill")).toThrow();
+    });
+  });
+
+  // ── Allowed paths ─────────────────────────────────────────────────
+
+  describe("allows valid paths within skill directory", () => {
+    it("readFile allows relative path within skill dir", async () => {
+      await expect(api.fs.readFile("data/config.json")).resolves.toBeDefined();
+    });
+
+    it("readFile allows simple filename", async () => {
+      await expect(api.fs.readFile("file.txt")).resolves.toBeDefined();
+    });
+
+    it("writeFile allows relative path within skill dir", async () => {
+      await expect(
+        api.fs.writeFile("output/result.json", "{}"),
+      ).resolves.toBeUndefined();
+    });
+
+    it("readdir allows current directory", async () => {
+      await expect(api.fs.readdir(".")).resolves.toBeDefined();
+    });
+
+    it("exists allows subdirectory", async () => {
+      await expect(api.fs.exists("subdir")).resolves.toBeDefined();
+    });
+
+    it("existsSync allows subdirectory", () => {
+      expect(() => api.fs.existsSync("subdir")).not.toThrow();
+    });
+
+    it("readFileSync allows relative path", () => {
+      expect(() => api.fs.readFileSync("data.txt")).not.toThrow();
+    });
+  });
+
+  // ── Edge cases ────────────────────────────────────────────────────
+
+  describe("edge cases", () => {
+    it("rejects path with embedded null byte", async () => {
+      await expect(api.fs.readFile("data\0../../etc")).rejects.toThrow();
+    });
+
+    it("rejects path that resolves outside via middle '..'", async () => {
+      await expect(
+        api.fs.readFile("subdir/../../other-skill/file"),
+      ).rejects.toThrow();
+    });
+
+    it("allows path with '..' that stays inside skill dir", async () => {
+      // e.g. "subdir/../file.txt" resolves to "file.txt" which is still inside
+      await expect(
+        api.fs.readFile("subdir/../file.txt"),
+      ).resolves.toBeDefined();
+    });
+  });
+});

--- a/packages/browser-runtime/src/lib/vm/skill-api.test.ts
+++ b/packages/browser-runtime/src/lib/vm/skill-api.test.ts
@@ -6,7 +6,7 @@
  * files belonging to other skills within the virtual filesystem.
  */
 
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createSkillAPIBridge } from "./skill-api";
 
 // Mock zenfs-manager so we don't need a real IndexedDB / ZenFS backend

--- a/packages/browser-runtime/src/lib/vm/skill-api.ts
+++ b/packages/browser-runtime/src/lib/vm/skill-api.ts
@@ -4,6 +4,7 @@
  * between QuickJS VM and the host environment
  */
 
+import { posix as posixPath } from "node:path";
 import type { FileStats } from "./types";
 import { zenfs } from "./zenfs-manager";
 
@@ -70,6 +71,42 @@ export interface SkillAPIBridge {
 }
 
 /**
+ * Resolve and validate a filesystem path so it stays within the skill's
+ * own directory (/skills/<skillId>/).
+ *
+ * - Rejects paths containing null bytes.
+ * - Treats the incoming path as relative to the skill root.
+ * - Normalizes away any ".." / "." segments via posix path resolution.
+ * - Throws if the resolved absolute path escapes the skill directory.
+ *
+ * @returns The absolute path within the virtual filesystem.
+ */
+export function resolveSafePath(skillId: string, userPath: string): string {
+  // Reject null bytes which could be used to truncate path strings
+  if (userPath.includes("\0")) {
+    throw new Error(
+      `[SKILL_API] Invalid path: null bytes are not allowed: ${userPath}`,
+    );
+  }
+
+  const skillRoot = `/skills/${skillId}`;
+
+  // Resolve the user-supplied path relative to the skill root.
+  // posixPath.resolve("/skills/abc", "../../x") → "/x"
+  // posixPath.resolve("/skills/abc", "sub/../file") → "/skills/abc/file"
+  const resolved = posixPath.resolve(skillRoot, userPath);
+
+  // The resolved path must be exactly skillRoot or start with skillRoot + "/"
+  if (resolved !== skillRoot && !resolved.startsWith(`${skillRoot}/`)) {
+    throw new Error(
+      `[SKILL_API] Path traversal denied: "${userPath}" resolves outside skill directory`,
+    );
+  }
+
+  return resolved;
+}
+
+/**
  * Create a SKILL_API bridge instance
  */
 export function createSkillAPIBridge(options: {
@@ -77,6 +114,14 @@ export function createSkillAPIBridge(options: {
   onToolRegister?: (tool: ToolDefinition) => Promise<void>;
 }): SkillAPIBridge {
   const { skillId, onToolRegister } = options;
+
+  /**
+   * Helper: resolve + validate a path supplied by skill code.
+   * Every fs operation MUST call this before touching zenfs.
+   */
+  function safePath(userPath: string): string {
+    return resolveSafePath(skillId, userPath);
+  }
 
   return {
     // Tool Registration
@@ -96,9 +141,13 @@ export function createSkillAPIBridge(options: {
         path: string,
         encoding?: string,
       ): Promise<string | Uint8Array> {
-        console.log(`[SKILL_API] fs.readFile: ${path}`);
+        const resolved = safePath(path);
+        console.log(`[SKILL_API] fs.readFile: ${resolved}`);
 
-        const result = await zenfs.readFile(path, encoding as BufferEncoding);
+        const result = await zenfs.readFile(
+          resolved,
+          encoding as BufferEncoding,
+        );
 
         // Convert Buffer to Uint8Array before passing to VM
         // This is critical: Buffer objects don't serialize properly across VM boundary
@@ -116,46 +165,57 @@ export function createSkillAPIBridge(options: {
       },
 
       async writeFile(path: string, data: string | Uint8Array): Promise<void> {
-        console.log(`[SKILL_API] fs.writeFile: ${path}`);
-        await zenfs.writeFile(path, data);
+        const resolved = safePath(path);
+        console.log(`[SKILL_API] fs.writeFile: ${resolved}`);
+        await zenfs.writeFile(resolved, data);
       },
 
       async readdir(path: string): Promise<string[]> {
-        console.log(`[SKILL_API] fs.readdir: ${path}`);
-        return await zenfs.readdir(path);
+        const resolved = safePath(path);
+        console.log(`[SKILL_API] fs.readdir: ${resolved}`);
+        return await zenfs.readdir(resolved);
       },
 
       async exists(path: string): Promise<boolean> {
-        console.log(`[SKILL_API] fs.exists: ${path}`);
-        return await zenfs.exists(path);
+        const resolved = safePath(path);
+        console.log(`[SKILL_API] fs.exists: ${resolved}`);
+        return await zenfs.exists(resolved);
       },
 
       async mkdir(
         path: string,
         options?: { recursive?: boolean },
       ): Promise<void> {
-        console.log(`[SKILL_API] fs.mkdir: ${path}`);
-        await zenfs.mkdir(path, options);
+        const resolved = safePath(path);
+        console.log(`[SKILL_API] fs.mkdir: ${resolved}`);
+        await zenfs.mkdir(resolved, options);
       },
 
-      async rm(path: string, options?: { recursive?: boolean }): Promise<void> {
-        console.log(`[SKILL_API] fs.rm: ${path}`);
-        await zenfs.rm(path, options);
+      async rm(
+        path: string,
+        options?: { recursive?: boolean },
+      ): Promise<void> {
+        const resolved = safePath(path);
+        console.log(`[SKILL_API] fs.rm: ${resolved}`);
+        await zenfs.rm(resolved, options);
       },
 
       async stat(path: string): Promise<FileStats> {
-        console.log(`[SKILL_API] fs.stat: ${path}`);
-        return await zenfs.stat(path);
+        const resolved = safePath(path);
+        console.log(`[SKILL_API] fs.stat: ${resolved}`);
+        return await zenfs.stat(resolved);
       },
 
       existsSync(path: string): boolean {
-        console.log(`[SKILL_API] fs.existsSync: ${path}`);
-        return zenfs.existsSync(path);
+        const resolved = safePath(path);
+        console.log(`[SKILL_API] fs.existsSync: ${resolved}`);
+        return zenfs.existsSync(resolved);
       },
 
       readFileSync(path: string, encoding?: string): string | Uint8Array {
-        console.log(`[SKILL_API] fs.readFileSync: ${path}`);
-        const result = zenfs.readFileSync(path, encoding as BufferEncoding);
+        const resolved = safePath(path);
+        console.log(`[SKILL_API] fs.readFileSync: ${resolved}`);
+        const result = zenfs.readFileSync(resolved, encoding as BufferEncoding);
 
         // Convert Buffer to Uint8Array before passing to VM
         // This is critical: Buffer objects don't serialize properly across VM boundary
@@ -173,28 +233,33 @@ export function createSkillAPIBridge(options: {
       },
 
       writeFileSync(path: string, data: string | Uint8Array): void {
-        console.log(`[SKILL_API] fs.writeFileSync: ${path}`);
-        zenfs.writeFileSync(path, data);
+        const resolved = safePath(path);
+        console.log(`[SKILL_API] fs.writeFileSync: ${resolved}`);
+        zenfs.writeFileSync(resolved, data);
       },
 
       readdirSync(path: string): string[] {
-        console.log(`[SKILL_API] fs.readdirSync: ${path}`);
-        return zenfs.readdirSync(path);
+        const resolved = safePath(path);
+        console.log(`[SKILL_API] fs.readdirSync: ${resolved}`);
+        return zenfs.readdirSync(resolved);
       },
 
       mkdirSync(path: string, options?: { recursive?: boolean }): void {
-        console.log(`[SKILL_API] fs.mkdirSync: ${path}`);
-        zenfs.mkdirSync(path, options);
+        const resolved = safePath(path);
+        console.log(`[SKILL_API] fs.mkdirSync: ${resolved}`);
+        zenfs.mkdirSync(resolved, options);
       },
 
       rmSync(path: string, options?: { recursive?: boolean }): void {
-        console.log(`[SKILL_API] fs.rmSync: ${path}`);
-        zenfs.rmSync(path, options);
+        const resolved = safePath(path);
+        console.log(`[SKILL_API] fs.rmSync: ${resolved}`);
+        zenfs.rmSync(resolved, options);
       },
 
       statSync(path: string): FileStats {
-        console.log(`[SKILL_API] fs.statSync: ${path}`);
-        return zenfs.statSync(path);
+        const resolved = safePath(path);
+        console.log(`[SKILL_API] fs.statSync: ${resolved}`);
+        return zenfs.statSync(resolved);
       },
     },
 

--- a/packages/browser-runtime/src/lib/vm/skill-api.ts
+++ b/packages/browser-runtime/src/lib/vm/skill-api.ts
@@ -191,10 +191,7 @@ export function createSkillAPIBridge(options: {
         await zenfs.mkdir(resolved, options);
       },
 
-      async rm(
-        path: string,
-        options?: { recursive?: boolean },
-      ): Promise<void> {
+      async rm(path: string, options?: { recursive?: boolean }): Promise<void> {
         const resolved = safePath(path);
         console.log(`[SKILL_API] fs.rm: ${resolved}`);
         await zenfs.rm(resolved, options);


### PR DESCRIPTION
## Summary

The `SKILL_API.fs.*` bridge in `packages/browser-runtime/src/lib/vm/skill-api.ts` passes paths supplied by skill code directly to the zenfs filesystem mounted at `/skills`. Because no path validation occurs, a skill can read, overwrite, or delete files belonging to **other installed skills** by using `..` segments or absolute paths — breaking the per-skill isolation that the QuickJS sandbox is intended to enforce.

- **CWE:** [CWE-22 — Improper Limitation of a Pathname to a Restricted Directory](https://cwe.mitre.org/data/definitions/22.html)
- **Affected file:** `packages/browser-runtime/src/lib/vm/skill-api.ts`
- **Affected surface:** all 14 `fs` methods exposed to skills (`readFile`, `writeFile`, `readdir`, `exists`, `mkdir`, `rm`, `stat`, plus the `*Sync` variants)
- **Trust boundary:** sandboxed skill code → host-side virtual filesystem

### Data flow (before fix)

```
skill code (untrusted)
  → SKILL_API.fs.readFile("../other-skill/secrets.json")
  → zenfs.readFile("../other-skill/secrets.json")   // raw, unvalidated
  → reads /skills/other-skill/secrets.json
```

A malicious or compromised skill running under skillId `evil` could:

- `fs.readFile("../victim/credentials.json")` — read another skill's data
- `fs.writeFile("/skills/victim/index.js", payload)` — overwrite another skill's code
- `fs.rm("../victim", { recursive: true })` — delete another skill entirely
- `fs.readdir("/skills")` — enumerate every installed skill

## Fix

Introduce a `resolveSafePath(skillId, userPath)` helper and route every `fs.*` call through it before invoking zenfs.

The helper:

1. Rejects paths containing null bytes (defense against truncation tricks).
2. Resolves the user-supplied path against the skill's own root (`/skills/<skillId>`) using `posix.resolve`, which collapses `..`/`.` segments and absorbs absolute paths into the resolved string.
3. Verifies the resolved path is exactly `skillRoot` or starts with `skillRoot + "/"`. The trailing slash is important — it prevents the sibling-prefix bypass where `/skills/abc-evil` would otherwise be accepted as "starting with" `/skills/abc`.
4. Throws a descriptive error otherwise.

All 14 fs methods (async + sync) are updated to call `safePath()`. There is no parallel code path that bypasses the helper.

```ts
const resolved = posixPath.resolve(skillRoot, userPath);
if (resolved !== skillRoot && !resolved.startsWith(`${skillRoot}/`)) {
  throw new Error(`[SKILL_API] Path traversal denied: "${userPath}" ...`);
}
```

## Tests

Added 25 new unit tests in `skill-api.test.ts` covering:

- Plain `..` traversal (`../other/file`, `../../etc/passwd`)
- Absolute-path injection (`/skills/other`, `/etc/passwd`)
- Mixed segments (`sub/../../other`)
- Sibling-prefix bypass attempts (`/skills/<id>-evil/...`)
- Null-byte injection
- Legitimate in-scope paths (relative and absolute forms of the skill's own files)
- Coverage of every fs method, including the `*Sync` variants

Full test suite (`npm run preflight`) passes locally, including pre-existing tests.

## Security analysis

**Why this is exploitable.** Skills are explicitly designed to run untrusted third-party code in QuickJS, and the per-skill `/skills/<skillId>/` directory is the isolation boundary that callers rely on. The `fs` bridge previously passed paths through verbatim, so any skill could enumerate or mutate any other skill's files using standard path traversal — no exotic primitives required.

**Preconditions.** The user installs or runs a malicious skill. This is precisely the threat model the QuickJS sandbox exists to contain; treating it as a precondition would defeat the purpose of the sandbox. The fix is what makes cross-skill isolation actually hold.

**What the fix prevents.** Cross-skill read, write, and delete; enumeration of installed skills via `/skills`; escapes to arbitrary virtual-FS paths. It does not change behavior for legitimate in-scope paths.

### Adversarial review

Before submitting, we tried to disprove this. We checked whether zenfs itself enforces a chroot-style boundary on the `/skills` mount (it doesn't — it's a generic filesystem), whether the QuickJS marshalling layer normalizes or restricts paths (it forwards them as plain strings), and whether installation flows somehow prevent a skill from issuing arbitrary `fs` calls (they don't — the bridge is the only gate). We also confirmed there isn't a separate vetting/signing step that would make malicious skills out-of-scope; skills are user-installable and the sandbox is the documented trust boundary. The traversal is therefore reachable from the intended attacker model and not mitigated elsewhere.

cc @lewiswigmore
