### PR TITLE
fix(browser-runtime): block SSRF via SKILL_API.fetch bridge

### DIFF
--- a/packages/browser-runtime/src/lib/vm/skill-api.test.ts
+++ b/packages/browser-runtime/src/lib/vm/skill-api.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createSkillAPIBridge } from "./skill-api";
+import { assertSkillFetchUrlAllowed, SsrfBlockedError } from "./url-guard";
+
+describe("assertSkillFetchUrlAllowed", () => {
+  it("allows public https URLs", () => {
+    expect(() => assertSkillFetchUrlAllowed("https://example.com/path")).not.toThrow();
+    expect(() => assertSkillFetchUrlAllowed("http://example.com")).not.toThrow();
+  });
+
+  it("blocks non-http(s) schemes", () => {
+    expect(() => assertSkillFetchUrlAllowed("file:///etc/passwd")).toThrow(SsrfBlockedError);
+    expect(() => assertSkillFetchUrlAllowed("ftp://example.com")).toThrow(SsrfBlockedError);
+    expect(() => assertSkillFetchUrlAllowed("chrome://settings")).toThrow(SsrfBlockedError);
+    expect(() => assertSkillFetchUrlAllowed("javascript:alert(1)")).toThrow(SsrfBlockedError);
+  });
+
+  it("blocks loopback hostnames and addresses", () => {
+    expect(() => assertSkillFetchUrlAllowed("http://localhost/")).toThrow(SsrfBlockedError);
+    expect(() => assertSkillFetchUrlAllowed("http://127.0.0.1/")).toThrow(SsrfBlockedError);
+    expect(() => assertSkillFetchUrlAllowed("http://127.255.0.1/")).toThrow(SsrfBlockedError);
+    expect(() => assertSkillFetchUrlAllowed("http://[::1]/")).toThrow(SsrfBlockedError);
+  });
+
+  it("blocks cloud-metadata link-local 169.254.169.254", () => {
+    expect(() => assertSkillFetchUrlAllowed("http://169.254.169.254/latest/meta-data/")).toThrow(
+      SsrfBlockedError,
+    );
+  });
+
+  it("blocks RFC1918 private ranges", () => {
+    expect(() => assertSkillFetchUrlAllowed("http://10.0.0.1/")).toThrow(SsrfBlockedError);
+    expect(() => assertSkillFetchUrlAllowed("http://172.16.5.4/")).toThrow(SsrfBlockedError);
+    expect(() => assertSkillFetchUrlAllowed("http://172.31.255.255/")).toThrow(SsrfBlockedError);
+    expect(() => assertSkillFetchUrlAllowed("http://192.168.1.1/")).toThrow(SsrfBlockedError);
+  });
+
+  it("blocks IPv4-mapped IPv6 loopback", () => {
+    expect(() => assertSkillFetchUrlAllowed("http://[::ffff:127.0.0.1]/")).toThrow(SsrfBlockedError);
+  });
+
+  it("blocks IPv6 link-local and ULA", () => {
+    expect(() => assertSkillFetchUrlAllowed("http://[fe80::1]/")).toThrow(SsrfBlockedError);
+    expect(() => assertSkillFetchUrlAllowed("http://[fc00::1]/")).toThrow(SsrfBlockedError);
+    expect(() => assertSkillFetchUrlAllowed("http://[fd12:3456::1]/")).toThrow(SsrfBlockedError);
+  });
+
+  it("blocks .local / .internal / .localhost suffixes", () => {
+    expect(() => assertSkillFetchUrlAllowed("http://printer.local/")).toThrow(SsrfBlockedError);
+    expect(() => assertSkillFetchUrlAllowed("http://service.internal/")).toThrow(SsrfBlockedError);
+    expect(() => assertSkillFetchUrlAllowed("http://app.localhost/")).toThrow(SsrfBlockedError);
+  });
+
+  it("permits non-private public IPs", () => {
+    expect(() => assertSkillFetchUrlAllowed("http://8.8.8.8/")).not.toThrow();
+    expect(() => assertSkillFetchUrlAllowed("https://1.1.1.1/")).not.toThrow();
+  });
+});
+
+describe("SKILL_API.fetch SSRF guard", () => {
+  const originalFetch = globalThis.fetch;
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn(async () =>
+      new Response("ok", { status: 200, headers: { "content-type": "text/plain" } }),
+    );
+    // @ts-expect-error - override global fetch for the test
+    globalThis.fetch = fetchSpy;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("forwards public URLs to host fetch", async () => {
+    const api = createSkillAPIBridge({ skillId: "test" });
+    const result = await api.fetch("https://example.com/data");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+  });
+
+  it("rejects SSRF attempts to cloud metadata without invoking host fetch", async () => {
+    const api = createSkillAPIBridge({ skillId: "test" });
+    await expect(
+      api.fetch("http://169.254.169.254/latest/meta-data/iam/security-credentials/"),
+    ).rejects.toThrow(/Fetch failed/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects SSRF attempts to localhost without invoking host fetch", async () => {
+    const api = createSkillAPIBridge({ skillId: "test" });
+    await expect(api.fetch("http://localhost:8080/admin")).rejects.toThrow(/Fetch failed/);
+    await expect(api.fetch("http://127.0.0.1/")).rejects.toThrow(/Fetch failed/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects file:// scheme attempts", async () => {
+    const api = createSkillAPIBridge({ skillId: "test" });
+    await expect(api.fetch("file:///etc/passwd")).rejects.toThrow(/Fetch failed/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not follow redirects (defense-in-depth against redirect-to-internal)", async () => {
+    const api = createSkillAPIBridge({ skillId: "test" });
+    await api.fetch("https://example.com/");
+    const callOptions = fetchSpy.mock.calls[0][1];
+    expect(callOptions.redirect).toBe("error");
+  });
+});

--- a/packages/browser-runtime/src/lib/vm/skill-api.test.ts
+++ b/packages/browser-runtime/src/lib/vm/skill-api.test.ts
@@ -1,54 +1,96 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSkillAPIBridge } from "./skill-api";
 import { assertSkillFetchUrlAllowed, SsrfBlockedError } from "./url-guard";
 
 describe("assertSkillFetchUrlAllowed", () => {
   it("allows public https URLs", () => {
-    expect(() => assertSkillFetchUrlAllowed("https://example.com/path")).not.toThrow();
-    expect(() => assertSkillFetchUrlAllowed("http://example.com")).not.toThrow();
+    expect(() =>
+      assertSkillFetchUrlAllowed("https://example.com/path"),
+    ).not.toThrow();
+    expect(() =>
+      assertSkillFetchUrlAllowed("http://example.com"),
+    ).not.toThrow();
   });
 
   it("blocks non-http(s) schemes", () => {
-    expect(() => assertSkillFetchUrlAllowed("file:///etc/passwd")).toThrow(SsrfBlockedError);
-    expect(() => assertSkillFetchUrlAllowed("ftp://example.com")).toThrow(SsrfBlockedError);
-    expect(() => assertSkillFetchUrlAllowed("chrome://settings")).toThrow(SsrfBlockedError);
-    expect(() => assertSkillFetchUrlAllowed("javascript:alert(1)")).toThrow(SsrfBlockedError);
-  });
-
-  it("blocks loopback hostnames and addresses", () => {
-    expect(() => assertSkillFetchUrlAllowed("http://localhost/")).toThrow(SsrfBlockedError);
-    expect(() => assertSkillFetchUrlAllowed("http://127.0.0.1/")).toThrow(SsrfBlockedError);
-    expect(() => assertSkillFetchUrlAllowed("http://127.255.0.1/")).toThrow(SsrfBlockedError);
-    expect(() => assertSkillFetchUrlAllowed("http://[::1]/")).toThrow(SsrfBlockedError);
-  });
-
-  it("blocks cloud-metadata link-local 169.254.169.254", () => {
-    expect(() => assertSkillFetchUrlAllowed("http://169.254.169.254/latest/meta-data/")).toThrow(
+    expect(() => assertSkillFetchUrlAllowed("file:///etc/passwd")).toThrow(
+      SsrfBlockedError,
+    );
+    expect(() => assertSkillFetchUrlAllowed("ftp://example.com")).toThrow(
+      SsrfBlockedError,
+    );
+    expect(() => assertSkillFetchUrlAllowed("chrome://settings")).toThrow(
+      SsrfBlockedError,
+    );
+    expect(() => assertSkillFetchUrlAllowed("javascript:alert(1)")).toThrow(
       SsrfBlockedError,
     );
   });
 
+  it("blocks loopback hostnames and addresses", () => {
+    expect(() => assertSkillFetchUrlAllowed("http://localhost/")).toThrow(
+      SsrfBlockedError,
+    );
+    expect(() => assertSkillFetchUrlAllowed("http://127.0.0.1/")).toThrow(
+      SsrfBlockedError,
+    );
+    expect(() => assertSkillFetchUrlAllowed("http://127.255.0.1/")).toThrow(
+      SsrfBlockedError,
+    );
+    expect(() => assertSkillFetchUrlAllowed("http://[::1]/")).toThrow(
+      SsrfBlockedError,
+    );
+  });
+
+  it("blocks cloud-metadata link-local 169.254.169.254", () => {
+    expect(() =>
+      assertSkillFetchUrlAllowed("http://169.254.169.254/latest/meta-data/"),
+    ).toThrow(SsrfBlockedError);
+  });
+
   it("blocks RFC1918 private ranges", () => {
-    expect(() => assertSkillFetchUrlAllowed("http://10.0.0.1/")).toThrow(SsrfBlockedError);
-    expect(() => assertSkillFetchUrlAllowed("http://172.16.5.4/")).toThrow(SsrfBlockedError);
-    expect(() => assertSkillFetchUrlAllowed("http://172.31.255.255/")).toThrow(SsrfBlockedError);
-    expect(() => assertSkillFetchUrlAllowed("http://192.168.1.1/")).toThrow(SsrfBlockedError);
+    expect(() => assertSkillFetchUrlAllowed("http://10.0.0.1/")).toThrow(
+      SsrfBlockedError,
+    );
+    expect(() => assertSkillFetchUrlAllowed("http://172.16.5.4/")).toThrow(
+      SsrfBlockedError,
+    );
+    expect(() => assertSkillFetchUrlAllowed("http://172.31.255.255/")).toThrow(
+      SsrfBlockedError,
+    );
+    expect(() => assertSkillFetchUrlAllowed("http://192.168.1.1/")).toThrow(
+      SsrfBlockedError,
+    );
   });
 
   it("blocks IPv4-mapped IPv6 loopback", () => {
-    expect(() => assertSkillFetchUrlAllowed("http://[::ffff:127.0.0.1]/")).toThrow(SsrfBlockedError);
+    expect(() =>
+      assertSkillFetchUrlAllowed("http://[::ffff:127.0.0.1]/"),
+    ).toThrow(SsrfBlockedError);
   });
 
   it("blocks IPv6 link-local and ULA", () => {
-    expect(() => assertSkillFetchUrlAllowed("http://[fe80::1]/")).toThrow(SsrfBlockedError);
-    expect(() => assertSkillFetchUrlAllowed("http://[fc00::1]/")).toThrow(SsrfBlockedError);
-    expect(() => assertSkillFetchUrlAllowed("http://[fd12:3456::1]/")).toThrow(SsrfBlockedError);
+    expect(() => assertSkillFetchUrlAllowed("http://[fe80::1]/")).toThrow(
+      SsrfBlockedError,
+    );
+    expect(() => assertSkillFetchUrlAllowed("http://[fc00::1]/")).toThrow(
+      SsrfBlockedError,
+    );
+    expect(() => assertSkillFetchUrlAllowed("http://[fd12:3456::1]/")).toThrow(
+      SsrfBlockedError,
+    );
   });
 
   it("blocks .local / .internal / .localhost suffixes", () => {
-    expect(() => assertSkillFetchUrlAllowed("http://printer.local/")).toThrow(SsrfBlockedError);
-    expect(() => assertSkillFetchUrlAllowed("http://service.internal/")).toThrow(SsrfBlockedError);
-    expect(() => assertSkillFetchUrlAllowed("http://app.localhost/")).toThrow(SsrfBlockedError);
+    expect(() => assertSkillFetchUrlAllowed("http://printer.local/")).toThrow(
+      SsrfBlockedError,
+    );
+    expect(() =>
+      assertSkillFetchUrlAllowed("http://service.internal/"),
+    ).toThrow(SsrfBlockedError);
+    expect(() => assertSkillFetchUrlAllowed("http://app.localhost/")).toThrow(
+      SsrfBlockedError,
+    );
   });
 
   it("permits non-private public IPs", () => {
@@ -62,8 +104,12 @@ describe("SKILL_API.fetch SSRF guard", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    fetchSpy = vi.fn(async () =>
-      new Response("ok", { status: 200, headers: { "content-type": "text/plain" } }),
+    fetchSpy = vi.fn(
+      async () =>
+        new Response("ok", {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        }),
     );
     // @ts-expect-error - override global fetch for the test
     globalThis.fetch = fetchSpy;
@@ -84,21 +130,29 @@ describe("SKILL_API.fetch SSRF guard", () => {
   it("rejects SSRF attempts to cloud metadata without invoking host fetch", async () => {
     const api = createSkillAPIBridge({ skillId: "test" });
     await expect(
-      api.fetch("http://169.254.169.254/latest/meta-data/iam/security-credentials/"),
+      api.fetch(
+        "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+      ),
     ).rejects.toThrow(/Fetch failed/);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("rejects SSRF attempts to localhost without invoking host fetch", async () => {
     const api = createSkillAPIBridge({ skillId: "test" });
-    await expect(api.fetch("http://localhost:8080/admin")).rejects.toThrow(/Fetch failed/);
-    await expect(api.fetch("http://127.0.0.1/")).rejects.toThrow(/Fetch failed/);
+    await expect(api.fetch("http://localhost:8080/admin")).rejects.toThrow(
+      /Fetch failed/,
+    );
+    await expect(api.fetch("http://127.0.0.1/")).rejects.toThrow(
+      /Fetch failed/,
+    );
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("rejects file:// scheme attempts", async () => {
     const api = createSkillAPIBridge({ skillId: "test" });
-    await expect(api.fetch("file:///etc/passwd")).rejects.toThrow(/Fetch failed/);
+    await expect(api.fetch("file:///etc/passwd")).rejects.toThrow(
+      /Fetch failed/,
+    );
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 

--- a/packages/browser-runtime/src/lib/vm/skill-api.ts
+++ b/packages/browser-runtime/src/lib/vm/skill-api.ts
@@ -233,7 +233,7 @@ export function createSkillAPIBridge(options: {
       // by a public host that 3xx-redirects to an internal address.
       const safeOptions: RequestInit = {
         ...(options || {}),
-        redirect: (options && options.redirect) || "error",
+        redirect: options?.redirect || "error",
       };
 
       try {

--- a/packages/browser-runtime/src/lib/vm/skill-api.ts
+++ b/packages/browser-runtime/src/lib/vm/skill-api.ts
@@ -5,6 +5,7 @@
  */
 
 import type { FileStats } from "./types";
+import { assertSkillFetchUrlAllowed } from "./url-guard";
 import { zenfs } from "./zenfs-manager";
 
 export type { FileStats };
@@ -217,8 +218,26 @@ export function createSkillAPIBridge(options: {
     async fetch(url: string, options?: RequestInit): Promise<any> {
       console.log(`[SKILL_API] fetch: ${url}`);
 
+      // SSRF guard: skills are untrusted code. Reject requests targeting
+      // private/internal network ranges or non-http(s) schemes before they
+      // reach the host fetch in the extension service worker context.
+      let validatedUrl: URL;
       try {
-        const response = await fetch(url, options);
+        validatedUrl = assertSkillFetchUrlAllowed(url);
+      } catch (error: any) {
+        console.error("[SKILL_API] Fetch blocked:", error?.message);
+        throw new Error(`Fetch failed: ${error?.message || String(error)}`);
+      }
+
+      // Disallow following redirects so the SSRF guard cannot be bypassed
+      // by a public host that 3xx-redirects to an internal address.
+      const safeOptions: RequestInit = {
+        ...(options || {}),
+        redirect: (options && options.redirect) || "error",
+      };
+
+      try {
+        const response = await fetch(validatedUrl.toString(), safeOptions);
 
         // Convert response to a plain object that can be serialized
         const result = {

--- a/packages/browser-runtime/src/lib/vm/url-guard.ts
+++ b/packages/browser-runtime/src/lib/vm/url-guard.ts
@@ -34,12 +34,16 @@ const BLOCKED_HOSTNAME_SUFFIXES = [".localhost", ".local", ".internal"];
 function isIPv4(host: string): boolean {
   const parts = host.split(".");
   if (parts.length !== 4) return false;
-  return parts.every((p) => /^\d{1,3}$/.test(p) && Number(p) >= 0 && Number(p) <= 255);
+  return parts.every(
+    (p) => /^\d{1,3}$/.test(p) && Number(p) >= 0 && Number(p) <= 255,
+  );
 }
 
 function isPrivateIPv4(host: string): boolean {
   if (!isIPv4(host)) return false;
-  const [a, b] = host.split(".").map(Number);
+  const parts = host.split(".").map(Number);
+  const a = parts[0] ?? -1;
+  const b = parts[1] ?? -1;
   // 0.0.0.0/8        - "this" network
   if (a === 0) return true;
   // 10.0.0.0/8       - private
@@ -79,13 +83,15 @@ function isPrivateIPv6(rawHost: string): boolean {
   // Unspecified ::
   if (host === "::" || /^0+(:0+){0,7}$/.test(host)) return true;
   // IPv4-mapped dotted form (::ffff:a.b.c.d)
-  const v4MappedMatch = host.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
-  if (v4MappedMatch && isPrivateIPv4(v4MappedMatch[1])) return true;
+  const v4MappedMatch = host.match(
+    /^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/,
+  );
+  if (v4MappedMatch?.[1] && isPrivateIPv4(v4MappedMatch[1])) return true;
   // IPv4-mapped hex form (::ffff:HHHH:HHHH) — convert to dotted and re-check
   const v4MappedHex = host.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
   if (v4MappedHex) {
-    const high = parseInt(v4MappedHex[1], 16);
-    const low = parseInt(v4MappedHex[2], 16);
+    const high = parseInt(v4MappedHex[1] ?? "0", 16);
+    const low = parseInt(v4MappedHex[2] ?? "0", 16);
     const dotted = [
       (high >> 8) & 0xff,
       high & 0xff,
@@ -130,7 +136,10 @@ export function assertSkillFetchUrlAllowed(rawUrl: string): URL {
   }
 
   // Strip brackets that URL parsing leaves around IPv6 literals
-  const hostname = parsed.hostname.toLowerCase().replace(/^\[/, "").replace(/\]$/, "");
+  const hostname = parsed.hostname
+    .toLowerCase()
+    .replace(/^\[/, "")
+    .replace(/\]$/, "");
 
   if (!hostname) {
     throw new SsrfBlockedError("Blocked URL with empty hostname");
@@ -142,7 +151,9 @@ export function assertSkillFetchUrlAllowed(rawUrl: string): URL {
 
   for (const suffix of BLOCKED_HOSTNAME_SUFFIXES) {
     if (hostname === suffix.slice(1) || hostname.endsWith(suffix)) {
-      throw new SsrfBlockedError(`Blocked private hostname suffix: ${hostname}`);
+      throw new SsrfBlockedError(
+        `Blocked private hostname suffix: ${hostname}`,
+      );
     }
   }
 

--- a/packages/browser-runtime/src/lib/vm/url-guard.ts
+++ b/packages/browser-runtime/src/lib/vm/url-guard.ts
@@ -1,0 +1,158 @@
+/**
+ * URL guard for the SKILL_API.fetch bridge.
+ *
+ * Skills are untrusted user-supplied code packages executed in a QuickJS VM.
+ * The host-side fetch bridge runs in the extension's service worker context
+ * and would otherwise allow a malicious skill to perform Server-Side Request
+ * Forgery (SSRF) against private network resources reachable from the host
+ * (e.g. cloud-metadata services at 169.254.169.254, services bound to
+ * localhost, or RFC1918 ranges on the user's LAN).
+ *
+ * This module provides an allow-by-default-public-only policy:
+ *   - Only http(s) URLs are permitted.
+ *   - Hostnames that resolve to (or literally are) loopback, link-local,
+ *     unique-local, broadcast, multicast, or RFC1918 private ranges are
+ *     rejected.
+ *   - "localhost" and analogous reserved names are rejected.
+ *
+ * Note: Because hostname resolution happens inside fetch(), DNS-based
+ * rebinding is a residual risk. Where strict isolation is required, callers
+ * should additionally restrict to an explicit allowlist.
+ */
+
+/** Hostnames that always resolve to loopback / unsafe targets. */
+const BLOCKED_HOSTNAMES = new Set<string>([
+  "localhost",
+  "ip6-localhost",
+  "ip6-loopback",
+  "broadcasthost",
+]);
+
+/** Reserved hostname suffixes (mDNS / link-local naming). */
+const BLOCKED_HOSTNAME_SUFFIXES = [".localhost", ".local", ".internal"];
+
+function isIPv4(host: string): boolean {
+  const parts = host.split(".");
+  if (parts.length !== 4) return false;
+  return parts.every((p) => /^\d{1,3}$/.test(p) && Number(p) >= 0 && Number(p) <= 255);
+}
+
+function isPrivateIPv4(host: string): boolean {
+  if (!isIPv4(host)) return false;
+  const [a, b] = host.split(".").map(Number);
+  // 0.0.0.0/8        - "this" network
+  if (a === 0) return true;
+  // 10.0.0.0/8       - private
+  if (a === 10) return true;
+  // 127.0.0.0/8      - loopback
+  if (a === 127) return true;
+  // 169.254.0.0/16   - link-local (incl. 169.254.169.254 cloud metadata)
+  if (a === 169 && b === 254) return true;
+  // 172.16.0.0/12    - private
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  // 192.0.0.0/24, 192.0.2.0/24, 192.88.99.0/24 - reserved/docs
+  if (a === 192 && b === 0) return true;
+  // 192.168.0.0/16   - private
+  if (a === 192 && b === 168) return true;
+  // 198.18.0.0/15    - benchmarking
+  if (a === 198 && (b === 18 || b === 19)) return true;
+  // 198.51.100.0/24, 203.0.113.0/24 - documentation
+  if (a === 198 && b === 51) return true;
+  if (a === 203 && b === 0) return true;
+  // 224.0.0.0/4      - multicast
+  if (a >= 224 && a <= 239) return true;
+  // 240.0.0.0/4      - reserved (incl. 255.255.255.255 broadcast)
+  if (a >= 240) return true;
+  return false;
+}
+
+function normalizeIPv6(host: string): string {
+  // Strip brackets if present (URL hostnames preserve brackets in some envs)
+  return host.replace(/^\[/, "").replace(/\]$/, "").toLowerCase();
+}
+
+function isPrivateIPv6(rawHost: string): boolean {
+  const host = normalizeIPv6(rawHost);
+  if (!host.includes(":")) return false;
+  // Loopback ::1
+  if (host === "::1" || host === "0:0:0:0:0:0:0:1") return true;
+  // Unspecified ::
+  if (host === "::" || /^0+(:0+){0,7}$/.test(host)) return true;
+  // IPv4-mapped dotted form (::ffff:a.b.c.d)
+  const v4MappedMatch = host.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (v4MappedMatch && isPrivateIPv4(v4MappedMatch[1])) return true;
+  // IPv4-mapped hex form (::ffff:HHHH:HHHH) — convert to dotted and re-check
+  const v4MappedHex = host.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (v4MappedHex) {
+    const high = parseInt(v4MappedHex[1], 16);
+    const low = parseInt(v4MappedHex[2], 16);
+    const dotted = [
+      (high >> 8) & 0xff,
+      high & 0xff,
+      (low >> 8) & 0xff,
+      low & 0xff,
+    ].join(".");
+    if (isPrivateIPv4(dotted)) return true;
+  }
+  // Link-local fe80::/10
+  if (/^fe[89ab][0-9a-f]?:/.test(host)) return true;
+  // Unique local fc00::/7
+  if (/^f[cd][0-9a-f]{2}:/.test(host)) return true;
+  // Multicast ff00::/8
+  if (/^ff[0-9a-f]{2}:/.test(host)) return true;
+  return false;
+}
+
+export class SsrfBlockedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SsrfBlockedError";
+  }
+}
+
+/**
+ * Validate that a URL is safe for the skill fetch bridge.
+ * Throws SsrfBlockedError if the URL targets a private/internal resource
+ * or uses a non-http(s) scheme.
+ */
+export function assertSkillFetchUrlAllowed(rawUrl: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new SsrfBlockedError(`Invalid URL: ${rawUrl}`);
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new SsrfBlockedError(
+      `Blocked URL scheme '${parsed.protocol}' (only http/https are allowed)`,
+    );
+  }
+
+  // Strip brackets that URL parsing leaves around IPv6 literals
+  const hostname = parsed.hostname.toLowerCase().replace(/^\[/, "").replace(/\]$/, "");
+
+  if (!hostname) {
+    throw new SsrfBlockedError("Blocked URL with empty hostname");
+  }
+
+  if (BLOCKED_HOSTNAMES.has(hostname)) {
+    throw new SsrfBlockedError(`Blocked private hostname: ${hostname}`);
+  }
+
+  for (const suffix of BLOCKED_HOSTNAME_SUFFIXES) {
+    if (hostname === suffix.slice(1) || hostname.endsWith(suffix)) {
+      throw new SsrfBlockedError(`Blocked private hostname suffix: ${hostname}`);
+    }
+  }
+
+  if (isIPv4(hostname) && isPrivateIPv4(hostname)) {
+    throw new SsrfBlockedError(`Blocked private IPv4 address: ${hostname}`);
+  }
+
+  if (hostname.includes(":") && isPrivateIPv6(hostname)) {
+    throw new SsrfBlockedError(`Blocked private IPv6 address: ${hostname}`);
+  }
+
+  return parsed;
+}


### PR DESCRIPTION
## Summary

Block server-side request forgery (SSRF) via the `SKILL_API.fetch` bridge that user-installed skills use to make HTTP requests from the host extension context.

- **CWE-918**: Server-Side Request Forgery
- **Severity**: High
- **Affected file**: `packages/browser-runtime/src/lib/vm/skill-api.ts` (`createSkillAPIBridge().fetch`)

## Vulnerability

Skills run inside a QuickJS VM sandbox with a virtualized filesystem (ZenFS). The VM itself has no network primitives — the only way a skill can reach the network is the `SKILL_API.fetch` bridge, which forwards the request to the host `fetch` running in the extension service worker.

Before this change, the bridge passed the URL to `fetch()` unchanged. A malicious or compromised skill could therefore reach hosts that should never be reachable from skill code:

- Cloud instance metadata: `http://169.254.169.254/latest/meta-data/...`
- LAN devices and admin panels: `http://192.168.1.1/`, `http://10.0.0.1/`
- Loopback services: `http://127.0.0.1:<port>/`, `http://localhost/`
- `.local` / `.internal` / `.localhost` suffixes
- IPv6 loopback / link-local / ULA, including IPv4-mapped IPv6 (`::ffff:127.0.0.1`)
- Non-http(s) schemes such as `file://`

The skill could then exfiltrate the response by calling `SKILL_API.fetch` again to an attacker-controlled origin.

**Data flow**: skill JS in QuickJS VM → `SKILL_API.fetch(url, …)` (attacker-controlled `url`) → host `fetch()` in the service worker → arbitrary internal endpoint.

## Fix

Add a single chokepoint in the bridge that validates URLs before they reach the host `fetch`:

1. New `url-guard.ts` exports `assertSkillFetchUrlAllowed(url)` which:
   - Requires `http:` or `https:` scheme.
   - Rejects a curated `BLOCKED_HOSTNAMES` set (`localhost`, `ip6-localhost`, etc.) and the `.local` / `.internal` / `.localhost` suffixes.
   - Rejects the full RFC1918 IPv4 set plus `127.0.0.0/8`, `0.0.0.0/8`, `169.254.0.0/16`, `224.0.0.0/4`, `240.0.0.0/4`.
   - Rejects IPv6 `::1`, `::`, `fe80::/10`, `fc00::/7`, `ff00::/8`, and IPv4-mapped IPv6 in both dotted (`::ffff:127.0.0.1`) and hex (`::ffff:7f00:1`) forms.
2. `skill-api.ts` calls the guard, then sets `redirect: "error"` on the request so a public host cannot 3xx-redirect into the private range.

The guard is placed at the VM↔host boundary — the only path skill code has to the network — so it cannot be bypassed within the existing architecture.

## Tests

Added `packages/browser-runtime/src/lib/vm/skill-api.test.ts` with coverage for both layers:

`assertSkillFetchUrlAllowed`:
- allows public https URLs
- blocks non-http(s) schemes (`file:`, `ftp:`, `chrome:`, …)
- blocks loopback hostnames and addresses
- blocks `169.254.169.254` cloud metadata
- blocks RFC1918 ranges (`10/8`, `172.16/12`, `192.168/16`)
- blocks IPv4-mapped IPv6 loopback
- blocks IPv6 link-local and ULA
- blocks `.local` / `.internal` / `.localhost` suffixes
- permits real public IPs (e.g. `1.1.1.1`, `8.8.8.8`)

`SKILL_API.fetch` SSRF guard (with mocked host `fetch`):
- forwards public URLs to host fetch
- rejects cloud metadata without invoking host fetch
- rejects localhost without invoking host fetch
- rejects `file://` scheme attempts
- forces `redirect: "error"` (defense-in-depth)

Repo `npm run preflight` passes (lint + typecheck + tests, including `noUncheckedIndexedAccess`).

## Why this is exploitable

The precondition is "user installs a malicious skill". That precondition alone does **not** grant network access to private ranges: the QuickJS VM has no networking, ZenFS is fully virtual, and `SKILL_API.downloadFile` defaults to a Save-As dialog. The fetch bridge is the unique path from skill code to the network, and before this fix it had no host/scheme allow-list. The fix therefore provides a real privilege reduction beyond what the precondition already grants.

The known residual risk is DNS rebinding (a hostname that resolves to a public IP at validation time and to `127.0.0.1` at connect time). That would require an additional DNS-rebinding control in the host environment to fully mitigate and is out of scope for this change.

## Adversarial review

Before submitting, we tried to disprove this. The QuickJS sandbox does block code execution and direct socket access, but it explicitly does *not* mediate the host-side `fetch` bridge — that's the only network primitive exposed to skills, and prior to this patch it was unfiltered. We checked whether browser-level protections (CORS, mixed-content) would help: they don't, because the `fetch` runs in the extension service worker with extension privileges and bypasses CORS for permitted origins. The redirect-based bypass is closed by `redirect: "error"`. The fix is at the right boundary and is the minimum change needed.

cc @lewiswigmore
