### PR TITLE
Add Requesty as an OpenAI-compatible provider

### DIFF
--- a/packages/core/src/config/ai-providers.ts
+++ b/packages/core/src/config/ai-providers.ts
@@ -69,6 +69,20 @@ export const AI_PROVIDERS = {
     docs: "https://openrouter.ai/keys",
     providerType: "openai",
   },
+  requesty: {
+    name: "Requesty",
+    icon: "🔀",
+    host: "https://router.requesty.ai/v1",
+    models: [
+      "openai/gpt-4o-mini",
+      "anthropic/claude-sonnet-4-5",
+      "google/gemini-2.5-flash",
+      "deepseek/deepseek-chat",
+    ] as const,
+    tokenPlaceholder: "sk-...",
+    docs: "https://app.requesty.ai/api-keys",
+    providerType: "openai",
+  },
   deepseek: {
     name: "DeepSeek",
     icon: "🔍",
@@ -180,6 +194,7 @@ export function detectProviderFromHost(host: string): AIProviderKey {
   if (host.includes("anthropic.com")) return "anthropic";
   if (host.includes("generativelanguage.googleapis.com")) return "google";
   if (host.includes("openrouter.ai")) return "openrouter";
+  if (host.includes("requesty.ai")) return "requesty";
   if (host.includes("deepseek.com")) return "deepseek";
   if (host.includes("groq.com")) return "groq";
   if (host.includes("together.xyz")) return "together";


### PR DESCRIPTION
This adds a dedicated `requesty` provider to the AI provider registry (`packages/core/src/config/ai-providers.ts`), mirroring the existing OpenRouter entry as closely as possible.

What this does:
* Adds a `requesty` entry to the `AI_PROVIDERS` map with `host: "https://router.requesty.ai/v1"`, `providerType: "openai"`, a starter model list, and the keys/docs links. Because `AIProviderKey` is derived as `keyof typeof AI_PROVIDERS`, the new id is picked up by the type automatically.
* Adds `if (host.includes("requesty.ai")) return "requesty";` to `detectProviderFromHost`, next to the existing OpenRouter mapping.

Requesty is an OpenAI-compatible LLM gateway, so it routes through the same `providerType: "openai"` client path as OpenRouter (no new client code needed). Model naming is `provider/model`, same convention as OpenRouter.

Verification: I tested the endpoint live before opening this. `GET https://router.requesty.ai/v1/models` returned 200 (572 models), and a chat completion with `openai/gpt-4o-mini` against `https://router.requesty.ai/v1/chat/completions` returned 200.

Docs: https://requesty.ai , https://app.requesty.ai/api-keys

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust wording/placement or close it if it's not a fit.