### PR TITLE
fix: restore skill creator script entry points

### DIFF
--- a/packages/browser-runtime/src/lib/vm/quickjs-manager.ts
+++ b/packages/browser-runtime/src/lib/vm/quickjs-manager.ts
@@ -434,15 +434,14 @@ class QuickJSManager {
     }
 
     return result;
-  } else if (module.exports) {
+  } else if (typeof module !== 'undefined' && module.exports) {
     if (typeof module.exports === 'function') {
       return module.exports(args);
     } else if (typeof module.exports === 'object' && 'main' in module.exports && typeof module.exports.main === 'function') {
       return module.exports.main(args);
     }
-  } else {
-    throw new Error('main function or module.exports not found')
   }
+  throw new Error('main function or module.exports not found')
 })()`;
 
       const resultHandle = scope.manage(

--- a/packages/browser-runtime/src/skill/built-in/skill-creator-browser/entrypoints.test.ts
+++ b/packages/browser-runtime/src/skill/built-in/skill-creator-browser/entrypoints.test.ts
@@ -1,0 +1,23 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const scriptNames = [
+  "init_skill.js",
+  "write_file.js",
+  "delete_file.js",
+  "quick_validate.js",
+  "package_skill.js",
+];
+
+describe("skill-creator script entry points", () => {
+  it.each(scriptNames)("exposes main in %s", async (scriptName) => {
+    const scriptPath = fileURLToPath(
+      new URL(`scripts/${scriptName}`, import.meta.url),
+    );
+    const code = await readFile(scriptPath, "utf8");
+
+    expect(code).toMatch(/async function main\(args\)/);
+    expect(code).not.toMatch(/async function _main\(args\)/);
+  });
+});

--- a/packages/browser-runtime/src/skill/built-in/skill-creator-browser/scripts/delete_file.js
+++ b/packages/browser-runtime/src/skill/built-in/skill-creator-browser/scripts/delete_file.js
@@ -8,7 +8,8 @@
  * Example:
  *    main({ path: '/skills/my-skill/SKILL.md' })
  */
-async function _main(args) {
+// biome-ignore lint/correctness/noUnusedVariables: QuickJS invokes this entry point by name.
+async function main(args) {
   const { path } = args;
 
   if (!path) {

--- a/packages/browser-runtime/src/skill/built-in/skill-creator-browser/scripts/init_skill.js
+++ b/packages/browser-runtime/src/skill/built-in/skill-creator-browser/scripts/init_skill.js
@@ -297,7 +297,8 @@ function initSkill(skillName, basePath, fs) {
 
 // Browser-compatible module export
 // Main entry point for script execution
-async function _main(args) {
+// biome-ignore lint/correctness/noUnusedVariables: QuickJS invokes this entry point by name.
+async function main(args) {
   const { skillName, basePath } = args;
 
   if (!skillName) {

--- a/packages/browser-runtime/src/skill/built-in/skill-creator-browser/scripts/package_skill.js
+++ b/packages/browser-runtime/src/skill/built-in/skill-creator-browser/scripts/package_skill.js
@@ -281,7 +281,8 @@ async function packageSkill(skillPath, _outputDir = null) {
   }
 }
 
-async function _main(args) {
+// biome-ignore lint/correctness/noUnusedVariables: QuickJS invokes this entry point by name.
+async function main(args) {
   const { skillPath, outputDir } = args;
 
   if (!skillPath) {

--- a/packages/browser-runtime/src/skill/built-in/skill-creator-browser/scripts/quick_validate.js
+++ b/packages/browser-runtime/src/skill/built-in/skill-creator-browser/scripts/quick_validate.js
@@ -71,7 +71,8 @@ function validateSkill(skillPath, fs) {
 
 // Browser-compatible module export
 // Main entry point for script execution
-async function _main(args) {
+// biome-ignore lint/correctness/noUnusedVariables: QuickJS invokes this entry point by name.
+async function main(args) {
   const { skillPath } = args;
 
   return validateSkill(skillPath, fs);

--- a/packages/browser-runtime/src/skill/built-in/skill-creator-browser/scripts/write_file.js
+++ b/packages/browser-runtime/src/skill/built-in/skill-creator-browser/scripts/write_file.js
@@ -8,7 +8,8 @@
  * Example:
  *    main({ path: '/skills/my-skill/SKILL.md', content: '# My Skill\n\nThis is my skill.' })
  */
-async function _main(args) {
+// biome-ignore lint/correctness/noUnusedVariables: QuickJS invokes this entry point by name.
+async function main(args) {
   const { path, content } = args;
 
   if (!path) {


### PR DESCRIPTION
## Summary

- restore the documented `main(args)` entry point for all built-in skill creator scripts
- guard the optional CommonJS fallback so missing entry points report the intended error instead of `ReferenceError: module is not defined`
- add regression coverage that keeps all built-in script entry points aligned with the QuickJS runner

## Root cause

The scripts exposed `_main(args)`, while the QuickJS runner only invokes `main(args)` or `module.exports`. Biome treats the runtime-invoked `main` function as statically unused and suggests prefixing it with an underscore, so the entry points now include explicit lint suppressions explaining the runtime contract.

## Testing

- `pnpm exec biome check ...`
- `pnpm -r --if-present typecheck`
- `pnpm -r --if-present test`
- pre-push `fix end of files` and `typos` hooks
