### PR TITLE
fix: clean up cancelled CDP commands

### DIFF
--- a/packages/browser-runtime/src/automation/cdp-commander.test.ts
+++ b/packages/browser-runtime/src/automation/cdp-commander.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CdpCommander, rejectPendingCommands } from "./cdp-commander";
+
+describe("CdpCommander", () => {
+  let commandCallback: ((result?: unknown) => void) | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    commandCallback = undefined;
+    global.chrome = {
+      debugger: {
+        sendCommand: vi.fn((_target, _command, _params, callback) => {
+          commandCallback = callback as (result?: unknown) => void;
+        }),
+      },
+      runtime: { lastError: undefined },
+    } as unknown as typeof chrome;
+  });
+
+  it("rejects a pending CDP command when its signal is aborted", async () => {
+    const controller = new AbortController();
+    const pending = new CdpCommander(1, controller.signal).sendCommand(
+      "Accessibility.getFullAXTree",
+      {},
+    );
+    controller.abort(new Error("cancel CDP"));
+
+    await expect(pending).rejects.toThrow("cancel CDP");
+    expect(() => commandCallback?.({ nodes: [] })).not.toThrow();
+  });
+
+  it("rejects commands when debugger cleanup starts", async () => {
+    const pending = new CdpCommander(2).sendCommand("DOM.enable", {});
+    rejectPendingCommands(2, "Debugger detaching");
+
+    await expect(pending).rejects.toThrow(
+      "CDP command 'DOM.enable' aborted: Debugger detaching",
+    );
+  });
+
+  it("cleans up a command after its own timeout", async () => {
+    const pending = new CdpCommander(3).sendCommand("DOM.getDocument", {}, 50);
+    const assertion = expect(pending).rejects.toThrow("timed out after 50ms");
+    await vi.advanceTimersByTimeAsync(50);
+    await assertion;
+
+    expect(() => rejectPendingCommands(3, "late cleanup")).not.toThrow();
+  });
+});

--- a/packages/browser-runtime/src/automation/cdp-commander.ts
+++ b/packages/browser-runtime/src/automation/cdp-commander.ts
@@ -8,37 +8,58 @@ const DEFAULT_CDP_TIMEOUT = 10000;
 
 const pendingCommands = new Map<
   number,
-  Set<{ reject: (error: Error) => void; command: string }>
+  Set<{ abort: (error: Error) => void; command: string }>
 >();
 
 export function rejectPendingCommands(tabId: number, reason: string): void {
   const pending = pendingCommands.get(tabId);
   if (pending) {
-    for (const { reject, command } of pending) {
-      reject(new Error(`CDP command '${command}' aborted: ${reason}`));
+    for (const { abort, command } of [...pending]) {
+      abort(new Error(`CDP command '${command}' aborted: ${reason}`));
     }
-    pending.clear();
     pendingCommands.delete(tabId);
   }
 }
 
 export class CdpCommander {
-  constructor(readonly tabId: number) {}
+  constructor(
+    readonly tabId: number,
+    private readonly signal?: AbortSignal,
+  ) {}
 
   async sendCommand<T = unknown>(
     command: string,
     params: Record<string, unknown>,
     timeout: number = DEFAULT_CDP_TIMEOUT,
+    signal: AbortSignal | undefined = this.signal,
   ): Promise<T> {
     return new Promise((resolve, reject) => {
-      const pendingEntry = { reject, command };
-
-      const timeoutId = setTimeout(() => {
+      let settled = false;
+      let timeoutId: ReturnType<typeof setTimeout>;
+      const cleanup = () => {
+        clearTimeout(timeoutId);
+        signal?.removeEventListener("abort", handleAbort);
         const pending = pendingCommands.get(this.tabId);
-        if (pending) {
-          pending.delete(pendingEntry);
-        }
-        reject(
+        pending?.delete(pendingEntry);
+        if (pending?.size === 0) pendingCommands.delete(this.tabId);
+      };
+      const rejectCommand = (error: Error) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(error);
+      };
+      const handleAbort = () => {
+        rejectCommand(
+          signal?.reason instanceof Error
+            ? signal.reason
+            : new Error(`CDP command '${command}' aborted`),
+        );
+      };
+      const pendingEntry = { abort: rejectCommand, command };
+
+      timeoutId = setTimeout(() => {
+        rejectCommand(
           new Error(`CDP command '${command}' timed out after ${timeout}ms`),
         );
       }, timeout);
@@ -47,23 +68,25 @@ export class CdpCommander {
         pendingCommands.set(this.tabId, new Set());
       }
       pendingCommands.get(this.tabId)!.add(pendingEntry);
+      signal?.addEventListener("abort", handleAbort, { once: true });
+      if (signal?.aborted) {
+        handleAbort();
+        return;
+      }
 
       chrome.debugger.sendCommand(
         { tabId: this.tabId },
         command,
         params,
         (result) => {
-          clearTimeout(timeoutId);
-
-          const pending = pendingCommands.get(this.tabId);
-          if (pending) {
-            pending.delete(pendingEntry);
-          }
-
-          if (chrome.runtime.lastError) {
+          const lastError = chrome.runtime.lastError;
+          if (settled) return;
+          settled = true;
+          cleanup();
+          if (lastError) {
             reject(
               new Error(
-                `Failed to send CDP command '${command}': ${chrome.runtime.lastError.message}`,
+                `Failed to send CDP command '${command}': ${lastError.message}`,
               ),
             );
           } else {


### PR DESCRIPTION
## Problem

Pending CDP commands are rejected when the debugger detaches, but their timeout and abort resources are not consistently cleaned up. Late Chrome callbacks can also attempt to settle commands that have already timed out or been cancelled.

## Root cause

The pending-command registry stores raw reject callbacks and each completion path performs only partial cleanup. There is no shared single-settlement guard or AbortSignal integration.

## Changes

- Add optional AbortSignal support at the commander and per-command levels.
- Route timeout, signal cancellation, and debugger cleanup through one idempotent rejection path.
- Remove timeout and abort listeners and delete empty pending-command sets.
- Ignore late Chrome callbacks after a command has settled.
- Capture chrome.runtime.lastError synchronously inside the callback.

## Tests

- Added regression coverage for signal cancellation, debugger cleanup, timeout cleanup, and harmless late callbacks.
- Targeted Browser Runtime test: 3 passed.
- Full npm run preflight passed: Core 215, DOM Snapshot 132, Browser Runtime 147, AIPex React 109 passed / 10 skipped, Browser Extension 36.

Note: the pre-push hook reports failure because the existing formatter rewrites unrelated mcp-bridge files. Those unrelated changes were discarded; all typechecks and tests completed successfully.